### PR TITLE
:wrench: Allow icanboogie/inflector 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "szykra/resource-naming-strategy",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "license": "MIT",
     "keywords": ["doctrine", "symfony", "naming", "strategy", "resource", "orm"],
     "description": "Resource Naming Strategy for Doctrine ORM",
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "icanboogie/inflector": "~1.3.0",
+        "icanboogie/inflector": "~1.3.0|~2.0.0",
         "doctrine/orm": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
Hi, when switching to PHP 7.4, icanboogie/inflector 2.0 is required (avoid issue with curly braces) so it would be nice to allow the use of this package :) 

When executing my functional tests, queries were containing wrong table names ("grouptypes" instead "group_types").